### PR TITLE
Add option to "Hide Label"

### DIFF
--- a/tooorangey.EditorNotes/EditorNotes.controller.js
+++ b/tooorangey.EditorNotes/EditorNotes.controller.js
@@ -3,6 +3,7 @@
 function ($scope) {
     $scope.editorNotes = "<p>Have a lovely editing day!</p>";
     $scope.noteCssClass = "";
+    $scope.model.hideLabel = $scope.model.config.hideLabel == 1;
     if (typeof $scope.model.config.editornotes != "undefined") {
      //angular 1.2 $scope.editornotes = $sce.trustAsHtml($scope.model.config.editornotes);
        

--- a/tooorangey.EditorNotes/package.manifest
+++ b/tooorangey.EditorNotes/package.manifest
@@ -20,6 +20,12 @@
                     description: 'Notes to provide the editor on the doctype',
                     key: "editornotes",
                     view: "~/App_Plugins/tooorangey.EditorNotes/RichTextPreValueEditor.html"
+                },
+                {
+                    label: "Hide Label",
+                    description: 'Hides the property label/description when selected',
+                    key: "hideLabel",
+                    view: "boolean"
                 }
             ]
         }


### PR DESCRIPTION
This adds a "Hide Label" option to the PreValue Editor:
![prevalues](https://cloud.githubusercontent.com/assets/1396376/3047110/953b9bf0-e131-11e3-9c87-ff737863ef03.png)

**Example when selected:**
![notesnolabel](https://cloud.githubusercontent.com/assets/1396376/3047123/b2c4b012-e131-11e3-8f2f-3505c47493da.png)

**And not (as is currently):**
![noteslabel](https://cloud.githubusercontent.com/assets/1396376/3047144/de443a3c-e131-11e3-8ce9-7f17f0d0f410.png)
